### PR TITLE
Fix mixed content issue

### DIFF
--- a/js/ArticleView.js
+++ b/js/ArticleView.js
@@ -57,7 +57,7 @@
          "<!DOCTYPE html>" +
          "<html>" +
             "<head>" +
-               "<link href='http://fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'>" +
+               "<link href='//fonts.googleapis.com/css?family=Droid+Serif' rel='stylesheet' type='text/css'>" +
                "<link type='text/css' rel='stylesheet' href='" +
                   chrome.extension.getURL( "css/style.css" ) +
                "'></link>" +


### PR DESCRIPTION
On https sites, the browser shows a mixed content warning and prevents the font from being loaded. With this change, it will use https or http depending on the target site.
