### PR TITLE
Fix bug sanitizing svg elements

### DIFF
--- a/js/ArticleParser.js
+++ b/js/ArticleParser.js
@@ -374,10 +374,10 @@
       if( eElement )
       {
          eElement.id        = "";
-         eElement.className = "";
 
          if( eElement.removeAttribute )
          {
+            eElement.removeAttribute( "class" );
             eElement.removeAttribute( "style" );
             eElement.removeAttribute( "width" );
             eElement.removeAttribute( "height" );


### PR DESCRIPTION
`className` property of SVG elements is read-only value of `SVGAnimatedString` type.
One should not modify it.
![img](https://i.imgur.com/BwFbAuF.png)